### PR TITLE
Fix for stack naming

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,8 @@ class ServerlessManifestPlugin {
     var provider = this.serverless.getProvider('aws')
     var stage = provider.getStage()
     var region = provider.getRegion()
-    var params = { StackName: `${name}-${stage}` }
+    var stackName = provider.naming.getStackName();
+    var params = { StackName: `${stackName}` }
 
     return new Promise((resolve, reject) => {
       provider.request('CloudFormation', 'describeStacks', params, stage, region)


### PR DESCRIPTION
After some research, I found out how to get the name of the stack from serverless framework. Turns out once you get the provider, you can ask it for names using provider.naming.