### PR TITLE
fix 1.0.5 serverless deploy failure

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -483,9 +483,9 @@ function evaluateEnabled(enabled) {
 
 function hasCustomDomain(yaml = {}) {
   const { plugins, custom } = yaml
-  const customDomainEnabled = evaluateEnabled(custom.customDomain.enabled)
   if (hasPlugin(plugins, 'serverless-domain-manager') &&
-      custom && custom.customDomain && custom.customDomain.domainName && customDomainEnabled) {
+      custom && custom.customDomain && custom.customDomain.domainName &&
+      evaluateEnabled(custom.customDomain.enabled)) {
     return custom.customDomain
   }
   return false


### PR DESCRIPTION
## What's the issue
 `sls deploy` command would cause a deployment failure if `serverless.yml` doesn't specify `custom.customDomain` field. For example, if the user does not use `serverless-domain-manager` at all, its deploy would probably fail.
The error:
```
TypeError: Cannot read property 'enabled' of undefined
```

## Fix
This fix should ensure `enabled` option is properly fetched if necessary.