### PR TITLE
Support specifying function code directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ custom:
     postProcess: ./my-file-to-process-manifest-data.js
     # Set plugin log output to silent. Default false
     silent: false
+    # Path to the function code. Default serverless.yml location (process.cwd())
+    srcPath: ./dist
 
 plugins:
  - serverless-manifest-plugin


### PR DESCRIPTION
Adds support for transpiled TypeScript code by specifying the output directory for the JS code.  Although the primary use case is TypeScript, the function code directory can now be anywhere

https://github.com/DavidWells/serverless-manifest-plugin/issues/17