### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,25 +20,31 @@ class ServerlessManifestPlugin {
         options: {
           json: {
             usage: 'Output json only for programmatic usage',
+            type: 'boolean',
           },
           silent: {
             usage: 'Silence all console output during manifest creation',
+            type: 'boolean',
           },
           output: {
             usage: 'Output path for serverless manifest file. Default /.serverless/manifest.json',
             shortcut: 'o',
+            type: 'string',
           },
           disableOutput: {
             usage: 'Disable manifest.json from being created',
             shortcut: 'd',
+            type: 'boolean',
           },
           postProcess: {
             usage: 'Path to custom javascript function for additional processing',
             shortcut: 'p',
+            type: 'string',
           },
           location:{
             usage: 'Path to serverless root.  Default process.cwd()',
-            shortcut: 'l'
+            shortcut: 'l',
+            type: 'string',
           }
         },
       },


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - ServerlessManifestPlugin for "json", "silent", "output", "disableOutput", "postProcess", "location"
```