### PR TITLE
fix url issue with functions containing underscores

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -578,7 +578,7 @@ function getFunctionRuntimeExtension(runtime) {
 // ZazLambdaFunctionQualifiedArn
 function getFunctionData(functionName, outputs) {
   const liveFunctionData = outputs.filter((out) => {
-    return `${jsUcfirst(functionName)}` === out.OutputKey.replace('LambdaFunctionQualifiedArn', '')
+    return `${convertFunctionNameToQualifiedArnOutputKey(functionName)}` === out.OutputKey
   })
 
   if (liveFunctionData && liveFunctionData.length) {
@@ -596,8 +596,10 @@ function getFunctionNameFromArn(arn) {
   return arn.split(':')[6]
 }
 
-function jsUcfirst(string) {
-  return string.charAt(0).toUpperCase() + string.slice(1)
+function convertFunctionNameToQualifiedArnOutputKey(string) {
+  var converted = string.charAt(0).toUpperCase() + string.slice(1);
+  converted = converted.replaceAll("_", "Underscore");
+  return converted + "LambdaFunctionQualifiedArn";
 }
 
 function fsExistsSync(myDir) {


### PR DESCRIPTION
Function names containing underscores were failing the check against the OutputKey
in the stack outputs. For instance, a serverless function named "hello" was properly converted
to "Hello" and matched to "HelloLambdaFunctionQualifiedArn"; however a function named
"hello_world" would be converted to "Hello_world", but the actual arn in the
deployed function (on AWS at least; I did not test other providers) is
"HelloUnderscoreworldLambdaFunctionQualifiedArn"; this led to url's for this function not
appearing in the manifest.